### PR TITLE
applet: analyzer: writable/buildable pcapng construct structures

### DIFF
--- a/squishy/applets/analyzer/pcapng.py
+++ b/squishy/applets/analyzer/pcapng.py
@@ -9,8 +9,7 @@ from construct import (
 	Pass, Rebuild, RepeatUntil, Struct, Switch, len_, this
 )
 
-# We don't have a PEN, and don't want to get one
-# so we're stealing SGIs
+# We don't have a PEN, and don't want to get one so we're stealing SGIs
 block_pen = 59
 
 # We only have the user link types specified, we don't need the other as we
@@ -412,8 +411,8 @@ if __name__ == '__main__':
 			print(fs)
 
 	import sys
-	from os import path
-	from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+	from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+	from os       import path
 
 	parser = ArgumentParser(
 		formatter_class = ArgumentDefaultsHelpFormatter,

--- a/squishy/applets/analyzer/pcapng.py
+++ b/squishy/applets/analyzer/pcapng.py
@@ -268,9 +268,8 @@ enhanced_packet_block = 'Enhanced Packet' / Aligned(4, Struct(
 
 interface_statistics_block = 'Interface Statistics' / Struct(
 	'InterfaceID' / Hex(Int32ul),
-	'TimestampRaw' / Struct('High' / Hex(Int32ul), 'Low' / Hex(Int32ul)),
+	'Timestamp' / timestamp,
 )
-
 
 squishy_bus_type = 'Bus Type' / Enum(BitsInteger(3),
 	unknown = 0b000,

--- a/squishy/applets/analyzer/pcapng.py
+++ b/squishy/applets/analyzer/pcapng.py
@@ -234,16 +234,13 @@ option = 'Option' / Struct(
 	)
 )
 
-
-
-
 section_header_block = 'Section Header' / Struct(
-	'BOM'     / Hex(Const(b'\x4D\x3C\x2B\x1A')),
+	'BOM'     / Hex(Const(0x1A2B3C4D, Int32ul)),
 	'Version' / Struct(
-		'Major' / Hex(Int16ul),
-		'Minor' / Hex(Int16ul),
+		'Major' / Const(1, Int16ul),
+		'Minor' / Const(0, Int16ul),
 	),
-	'Section Len' / Hex(Int64sl),
+	'Section Len' / Default(Int64sl, -1),
 )
 
 interface_block = 'Interface Header' / Struct(

--- a/squishy/applets/analyzer/pcapng.py
+++ b/squishy/applets/analyzer/pcapng.py
@@ -43,6 +43,14 @@ link_type = 'Link Type' / Enum(Int16ul,
 	user_13 = 0x00A0,
 	user_14 = 0x00A1,
 	user_15 = 0x00A2,
+
+	usb_free_bsd = 0x00BA,
+	usb_linux = 0x00BD,
+	usb_linux_mem_mapped = 0x00DC,
+	usb_pcap = 0x00F9,
+	usb_darwin = 0x010A,
+	usb_open_vizsla = 0x0116,
+	usb_2_0 = 0x0120,
 )
 
 # Because of the limitations of some of the blocks

--- a/squishy/applets/analyzer/pcapng.py
+++ b/squishy/applets/analyzer/pcapng.py
@@ -243,9 +243,9 @@ section_header_block = 'Section Header' / Struct(
 	'Section Len' / Default(Int64sl, -1),
 )
 
-interface_block = 'Interface Header' / Struct(
+interface_description_block = 'Interface Description' / Struct(
 	'LinkType' / Hex(link_type),
-	'Reserved' / Hex(Int16ul),
+	'Reserved' / Hex(Const(0, Int16ul)),
 	'SnapLen'  / Hex(Int32ul),
 )
 
@@ -335,7 +335,7 @@ pcapng_block = 'Block' / Struct(
 	'Data'    / Switch(
 		this.Type, {
 			block_type.section_header: section_header_block,
-			block_type.interface: interface_block,
+			block_type.interface: interface_description_block,
 			block_type.enhanced_packet: enhanced_packet_block,
 			block_type.interface_stats: interface_statistics_block,
 		},


### PR DESCRIPTION
In this PR, we address the writability of the pcapng block structures to allow the creation of new pcapng files from captured data.

This allows the analyser applet to write the data captured out to file for Wireshark analysis.